### PR TITLE
43 api handle semantic failures in requests

### DIFF
--- a/edgeless_api/proto/messages.proto
+++ b/edgeless_api/proto/messages.proto
@@ -97,6 +97,16 @@ message SpawnWorkflowRequest {
     map<string, string> workflow_annotations = 4;
 }
 
+// Response to a request to create a new workflow.
+message SpawnWorkflowResponse {
+    // If present it means that the request has been rejected.
+    // In this case, the other fields may not be present or contain meaningful data.
+    optional ResponseError response_error = 1;
+
+    // The status of the newly-created workflow, if the request has been accepted.
+    optional WorkflowInstanceStatus workflow_status = 2;
+}
+
 // Function instance mapping.
 message WorkflowFunctionMapping {
     // Name of the function within the workflow.
@@ -176,3 +186,22 @@ message ResourceInstanceSpecification {
     // Map between the callbacks and instances that will be called.
     map<string, InstanceId> output_callback_definitions = 3;
 }
+
+// Message containing information provided as response to failed request.
+// The fields are inspired from the "problem detail" responses:
+//
+// https://www.rfc-editor.org/rfc/rfc7807.txt
+//
+// Currently all the fields are human-readable, i.e., they are intended to
+// be shown and processed by human operators. Further optional fields might be
+// added in the future that contain binary representations of information
+// intended for machine processing, instead.
+message ResponseError {
+    // A short, human-readable summary of the problem type.
+    // It should not change from occurrence to occurrence of the error.
+    string summary = 1;
+
+    // A human-readable explanation specific to this occurrence of the problem.
+    optional string detail = 2;
+}
+

--- a/edgeless_api/proto/messages.proto
+++ b/edgeless_api/proto/messages.proto
@@ -59,8 +59,7 @@ message SpawnFunctionResponse {
     // In this case, other fields may not be present or contain meaningful data.
     optional ResponseError response_error = 1;
 
-    // The identifier of the newly-spawned function instance, if the request
-    // has been accepted.
+    // The identifier of the newly-spawned function instance, if accepted.
     optional InstanceId instance_id = 2;
 }
 
@@ -114,8 +113,7 @@ message SpawnWorkflowResponse {
     // In this case, other fields may not be present or contain meaningful data.
     optional ResponseError response_error = 1;
 
-    // The status of the newly-created workflow, if the request has been
-    // accepted.
+    // The status of the newly-created workflow, if request accepted.
     optional WorkflowInstanceStatus workflow_status = 2;
 }
 
@@ -197,6 +195,16 @@ message ResourceInstanceSpecification {
     map<string, string> configuration = 2;
     // Map between the callbacks and instances that will be called.
     map<string, InstanceId> output_callback_definitions = 3;
+}
+
+// Response to a request to create a new resource.
+message SpawnResourceResponse {
+    // If present it means that the request has been rejected.
+    // In this case, other fields may not be present or contain meaningful data.
+    optional ResponseError response_error = 1;
+
+    // The status of the newly-created resource, if request accepted.
+    optional InstanceId instance_id = 2;
 }
 
 // Message containing information provided as response to failed request.

--- a/edgeless_api/proto/messages.proto
+++ b/edgeless_api/proto/messages.proto
@@ -53,6 +53,17 @@ message SpawnFunctionRequest {
     StateSpecification state_specification = 6;
 }
 
+// Message to request the creation a new function instance.
+message SpawnFunctionResponse {
+    // If present it means that the request has been rejected.
+    // In this case, other fields may not be present or contain meaningful data.
+    optional ResponseError response_error = 1;
+
+    // The identifier of the newly-spawned function instance, if the request
+    // has been accepted.
+    optional InstanceId instance_id = 2;
+}
+
 // Message to request the update of a function instance.
 message UpdateFunctionLinksRequest {
     // The function instance identifier.
@@ -100,10 +111,11 @@ message SpawnWorkflowRequest {
 // Response to a request to create a new workflow.
 message SpawnWorkflowResponse {
     // If present it means that the request has been rejected.
-    // In this case, the other fields may not be present or contain meaningful data.
+    // In this case, other fields may not be present or contain meaningful data.
     optional ResponseError response_error = 1;
 
-    // The status of the newly-created workflow, if the request has been accepted.
+    // The status of the newly-created workflow, if the request has been
+    // accepted.
     optional WorkflowInstanceStatus workflow_status = 2;
 }
 

--- a/edgeless_api/proto/services.proto
+++ b/edgeless_api/proto/services.proto
@@ -54,8 +54,8 @@ service FunctionInvocation {
 service ResourceConfiguration {
     // Create a new resource.
     // Input: specification of the resource to be created.
-    // Output: the identifier of the newly created resource.
-    rpc Start (ResourceInstanceSpecification) returns (InstanceId);
+    // Output: the identifier of the newly created resource, if accepted.
+    rpc Start (ResourceInstanceSpecification) returns (SpawnResourceResponse);
 
     // Terminate an existing resource.
     // Input: the identifier of the resource to be terminated.

--- a/edgeless_api/proto/services.proto
+++ b/edgeless_api/proto/services.proto
@@ -9,8 +9,8 @@ package edgeless_api;
 service FunctionInstance {
     // Start a new function instance.
     // Input: request containing the description of the function to create.
-    // Output: the function instance identifier assigned
-    rpc Start (SpawnFunctionRequest) returns (InstanceId);
+    // Output: the function instance identifier assigned, if accepted.
+    rpc Start (SpawnFunctionRequest) returns (SpawnFunctionResponse);
     
     // Stop a running function instance.
     // Input: the identifier of the function instance to tear down.

--- a/edgeless_api/proto/services.proto
+++ b/edgeless_api/proto/services.proto
@@ -28,14 +28,14 @@ service FunctionInstance {
 service WorkflowInstance {
     // Start a new workflow.
     // Input: request containing the description of the workflow to create.
-    // Output: the status of workflow instance newly created.
-    rpc Start (SpawnWorkflowRequest) returns (WorkflowInstanceStatus);
+    // Output: the status of workflow instance newly created, if accepted.
+    rpc Start (SpawnWorkflowRequest) returns (SpawnWorkflowResponse);
 
     // Stop an active workflow.
     // Input: the identifier of the workflow to tear down.
     // Output: none.
-
     rpc Stop (WorkflowId) returns (google.protobuf.Empty);
+
     // List the active workflows or shows the status of a given active workflow.
     // Input: the identifier of the active workflow or a special value indicating all workflows.
     // Output: the list of status of the active workflow instances.

--- a/edgeless_api/src/common/mod.rs
+++ b/edgeless_api/src/common/mod.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, Debug)]
+pub struct ResponseError {
+    pub summary: String,
+    pub detail: Option<String>,
+}

--- a/edgeless_api/src/function_instance/mod.rs
+++ b/edgeless_api/src/function_instance/mod.rs
@@ -65,6 +65,15 @@ pub struct SpawnFunctionResponse {
     pub instance_id: Option<InstanceId>,
 }
 
+impl SpawnFunctionResponse {
+    pub fn good(instance_id: crate::function_instance::InstanceId) -> Self {
+        Self {
+            response_error: None,
+            instance_id: Some(instance_id),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct UpdateFunctionLinksRequest {
     pub instance_id: Option<InstanceId>,

--- a/edgeless_api/src/function_instance/mod.rs
+++ b/edgeless_api/src/function_instance/mod.rs
@@ -1,3 +1,5 @@
+use crate::common::ResponseError;
+
 // TODO(raphaelhetzel) These should be actual types in the future to allow for type-safety.
 pub type NodeId = uuid::Uuid;
 pub type NodeLocalComponentId = uuid::Uuid;
@@ -57,6 +59,12 @@ pub struct SpawnFunctionRequest {
     pub state_specification: StateSpecification,
 }
 
+#[derive(Debug, Clone)]
+pub struct SpawnFunctionResponse {
+    pub response_error: Option<ResponseError>,
+    pub instance_id: Option<InstanceId>,
+}
+
 #[derive(Debug)]
 pub struct UpdateFunctionLinksRequest {
     pub instance_id: Option<InstanceId>,
@@ -65,7 +73,7 @@ pub struct UpdateFunctionLinksRequest {
 
 #[async_trait::async_trait]
 pub trait FunctionInstanceAPI: FunctionInstanceAPIClone + Sync + Send {
-    async fn start(&mut self, spawn_request: SpawnFunctionRequest) -> anyhow::Result<InstanceId>;
+    async fn start(&mut self, spawn_request: SpawnFunctionRequest) -> anyhow::Result<SpawnFunctionResponse>;
     async fn stop(&mut self, id: InstanceId) -> anyhow::Result<()>;
     async fn update_links(&mut self, update: UpdateFunctionLinksRequest) -> anyhow::Result<()>;
 }

--- a/edgeless_api/src/grpc_impl/common.rs
+++ b/edgeless_api/src/grpc_impl/common.rs
@@ -1,0 +1,17 @@
+pub struct CommonConverters {}
+
+impl CommonConverters {
+    pub fn parse_response_error(api_request: &crate::grpc_impl::api::ResponseError) -> anyhow::Result<crate::common::ResponseError> {
+        Ok(crate::common::ResponseError {
+            summary: api_request.summary.to_string(),
+            detail: api_request.detail.clone(),
+        })
+    }
+
+    pub fn serialize_response_error(crate_function: &crate::common::ResponseError) -> crate::grpc_impl::api::ResponseError {
+        crate::grpc_impl::api::ResponseError {
+            summary: crate_function.summary.clone(),
+            detail: crate_function.detail.clone(),
+        }
+    }
+}

--- a/edgeless_api/src/grpc_impl/common.rs
+++ b/edgeless_api/src/grpc_impl/common.rs
@@ -8,10 +8,24 @@ impl CommonConverters {
         })
     }
 
+    pub fn parse_instance_id(api_id: &crate::grpc_impl::api::InstanceId) -> anyhow::Result<crate::function_instance::InstanceId> {
+        Ok(crate::function_instance::InstanceId {
+            node_id: uuid::Uuid::parse_str(&api_id.node_id)?,
+            function_id: uuid::Uuid::parse_str(&api_id.function_id)?,
+        })
+    }
+
     pub fn serialize_response_error(crate_function: &crate::common::ResponseError) -> crate::grpc_impl::api::ResponseError {
         crate::grpc_impl::api::ResponseError {
             summary: crate_function.summary.clone(),
             detail: crate_function.detail.clone(),
+        }
+    }
+
+    pub fn serialize_instance_id(instance_id: &crate::function_instance::InstanceId) -> crate::grpc_impl::api::InstanceId {
+        crate::grpc_impl::api::InstanceId {
+            node_id: instance_id.node_id.to_string(),
+            function_id: instance_id.function_id.to_string(),
         }
     }
 }

--- a/edgeless_api/src/grpc_impl/function_instance.rs
+++ b/edgeless_api/src/grpc_impl/function_instance.rs
@@ -22,7 +22,7 @@ impl FunctonInstanceConverters {
         })
     }
 
-    pub fn parse_api_request(
+    pub fn parse_spawn_function_request(
         api_request: &crate::grpc_impl::api::SpawnFunctionRequest,
     ) -> anyhow::Result<crate::function_instance::SpawnFunctionRequest> {
         Ok(crate::function_instance::SpawnFunctionRequest {
@@ -49,7 +49,7 @@ impl FunctonInstanceConverters {
                 })
                 .collect(),
             annotations: api_request.annotations.clone(),
-            state_specification: Self::parse_api_state_specification(match &api_request.state_specification {
+            state_specification: Self::parse_state_specification(match &api_request.state_specification {
                 Some(val) => val,
                 None => {
                     return Err(anyhow::anyhow!("Request does not contain state_spec."));
@@ -79,7 +79,7 @@ impl FunctonInstanceConverters {
         })
     }
 
-    pub fn parse_api_function_link_update(
+    pub fn parse_update_function_links_request(
         api_update: &crate::grpc_impl::api::UpdateFunctionLinksRequest,
     ) -> anyhow::Result<crate::function_instance::UpdateFunctionLinksRequest> {
         Ok(crate::function_instance::UpdateFunctionLinksRequest {
@@ -102,7 +102,7 @@ impl FunctonInstanceConverters {
         })
     }
 
-    pub fn parse_api_state_specification(
+    pub fn parse_state_specification(
         api_spec: &crate::grpc_impl::api::StateSpecification,
     ) -> anyhow::Result<crate::function_instance::StateSpecification> {
         Ok(crate::function_instance::StateSpecification {
@@ -268,7 +268,7 @@ impl crate::grpc_impl::api::function_instance_server::FunctionInstance for Funct
         request: tonic::Request<crate::grpc_impl::api::SpawnFunctionRequest>,
     ) -> Result<tonic::Response<crate::grpc_impl::api::SpawnFunctionResponse>, tonic::Status> {
         let inner_request = request.into_inner();
-        let parsed_request = match FunctonInstanceConverters::parse_api_request(&inner_request) {
+        let parsed_request = match FunctonInstanceConverters::parse_spawn_function_request(&inner_request) {
             Ok(val) => val,
             Err(err) => {
                 return Ok(tonic::Response::new(crate::grpc_impl::api::SpawnFunctionResponse {
@@ -316,7 +316,7 @@ impl crate::grpc_impl::api::function_instance_server::FunctionInstance for Funct
         &self,
         update: tonic::Request<crate::grpc_impl::api::UpdateFunctionLinksRequest>,
     ) -> Result<tonic::Response<()>, tonic::Status> {
-        let parsed_update = match FunctonInstanceConverters::parse_api_function_link_update(&update.into_inner()) {
+        let parsed_update = match FunctonInstanceConverters::parse_update_function_links_request(&update.into_inner()) {
             Ok(parsed_update) => parsed_update,
             Err(err) => {
                 log::error!("Parse Update Failed: {}", err);

--- a/edgeless_api/src/grpc_impl/invocation.rs
+++ b/edgeless_api/src/grpc_impl/invocation.rs
@@ -1,3 +1,5 @@
+use super::common::CommonConverters;
+
 struct InvocationConverters {}
 
 const TYPE_CALL: i32 = crate::grpc_impl::api::EventType::Call as i32;
@@ -8,8 +10,8 @@ const TYPE_CALL_NO_RET: i32 = crate::grpc_impl::api::EventType::CallNoRet as i32
 impl InvocationConverters {
     fn parse_api_event(api_event: &crate::grpc_impl::api::Event) -> anyhow::Result<crate::invocation::Event> {
         Ok(crate::invocation::Event {
-            target: crate::grpc_impl::function_instance::FunctonInstanceConverters::parse_instance_id(&api_event.target.as_ref().unwrap())?,
-            source: crate::grpc_impl::function_instance::FunctonInstanceConverters::parse_instance_id(&api_event.source.as_ref().unwrap())?,
+            target: CommonConverters::parse_instance_id(&api_event.target.as_ref().unwrap())?,
+            source: CommonConverters::parse_instance_id(&api_event.source.as_ref().unwrap())?,
             stream_id: api_event.stream_id,
             data: Self::parse_api_event_data(&api_event.msg.as_ref().unwrap())?,
         })
@@ -27,12 +29,8 @@ impl InvocationConverters {
 
     fn encode_crate_event(crate_event: &crate::invocation::Event) -> crate::grpc_impl::api::Event {
         crate::grpc_impl::api::Event {
-            target: Some(crate::grpc_impl::function_instance::FunctonInstanceConverters::serialize_instance_id(
-                &crate_event.target,
-            )),
-            source: Some(crate::grpc_impl::function_instance::FunctonInstanceConverters::serialize_instance_id(
-                &crate_event.source,
-            )),
+            target: Some(CommonConverters::serialize_instance_id(&crate_event.target)),
+            source: Some(CommonConverters::serialize_instance_id(&crate_event.source)),
             stream_id: crate_event.stream_id,
             msg: Some(Self::encode_crate_event_data(&crate_event.data)),
         }

--- a/edgeless_api/src/grpc_impl/mod.rs
+++ b/edgeless_api/src/grpc_impl/mod.rs
@@ -1,17 +1,19 @@
-pub mod function_instance;
-
 pub mod agent;
-
-pub mod orc;
-
-pub mod controller;
-
-pub mod workflow_instance;
-
-pub mod invocation;
-
-pub mod resource_configuration;
 
 pub mod api {
     tonic::include_proto!("edgeless_api");
 }
+
+pub mod common;
+
+pub mod controller;
+
+pub mod function_instance;
+
+pub mod invocation;
+
+pub mod orc;
+
+pub mod resource_configuration;
+
+pub mod workflow_instance;

--- a/edgeless_api/src/grpc_impl/workflow_instance.rs
+++ b/edgeless_api/src/grpc_impl/workflow_instance.rs
@@ -327,7 +327,7 @@ impl crate::grpc_impl::api::workflow_instance_server::WorkflowInstance for Workf
             )),
             Err(err) => Ok(tonic::Response::new(crate::grpc_impl::api::SpawnWorkflowResponse {
                 response_error: Some(crate::grpc_impl::api::ResponseError {
-                    summary: "Requested rejected".to_string(),
+                    summary: "Request rejected".to_string(),
                     detail: Some(err.to_string()),
                 }),
                 workflow_status: None,

--- a/edgeless_api/src/lib.rs
+++ b/edgeless_api/src/lib.rs
@@ -1,18 +1,20 @@
-#[cfg(feature = "grpc_impl")]
-pub mod grpc_impl;
-
-pub mod function_instance;
-
-pub mod workflow_instance;
-
-pub mod resource_configuration;
-
 pub mod agent;
 
-pub mod orc;
+pub mod common;
 
 pub mod controller;
 
+pub mod function_instance;
+
+#[cfg(feature = "grpc_impl")]
+pub mod grpc_impl;
+
 pub mod invocation;
 
+pub mod orc;
+
+pub mod resource_configuration;
+
 pub mod util;
+
+pub mod workflow_instance;

--- a/edgeless_api/src/util.rs
+++ b/edgeless_api/src/util.rs
@@ -2,6 +2,7 @@ pub enum HttpProto {
     HTTP,
     HTTPS,
 }
+
 pub fn parse_http_host(raw: &str) -> anyhow::Result<(HttpProto, String, u16)> {
     let re = regex::Regex::new(r"(http[s]?):\/\/(.*):(\d+)").unwrap();
     let res = re.captures(raw);

--- a/edgeless_api/src/workflow_instance/mod.rs
+++ b/edgeless_api/src/workflow_instance/mod.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use crate::function_instance::InstanceId;
+use crate::{common::ResponseError, function_instance::InstanceId};
 
 const WORKFLOW_ID_NONE: uuid::Uuid = uuid::uuid!("00000000-0000-0000-0000-ffff00000000");
 
@@ -60,7 +60,7 @@ pub struct WorkflowFunction {
     pub function_annotations: std::collections::HashMap<String, String>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SpawnWorkflowRequest {
     pub workflow_id: WorkflowId,
     pub workflow_functions: Vec<WorkflowFunction>,
@@ -68,9 +68,15 @@ pub struct SpawnWorkflowRequest {
     pub workflow_annotations: std::collections::HashMap<String, String>,
 }
 
+#[derive(Clone, Debug)]
+pub struct SpawnWorkflowResponse {
+    pub response_error: Option<ResponseError>,
+    pub workflow_status: Option<WorkflowInstance>,
+}
+
 #[async_trait::async_trait]
 pub trait WorkflowInstanceAPI: WorkflowInstanceAPIClone + Send + Sync {
-    async fn start(&mut self, request: SpawnWorkflowRequest) -> anyhow::Result<WorkflowInstance>;
+    async fn start(&mut self, request: SpawnWorkflowRequest) -> anyhow::Result<SpawnWorkflowResponse>;
     async fn stop(&mut self, id: WorkflowId) -> anyhow::Result<()>;
     async fn list(&mut self, id: WorkflowId) -> anyhow::Result<Vec<WorkflowInstance>>;
 }

--- a/edgeless_api/src/workflow_instance/mod.rs
+++ b/edgeless_api/src/workflow_instance/mod.rs
@@ -74,6 +74,15 @@ pub struct SpawnWorkflowResponse {
     pub workflow_status: Option<WorkflowInstance>,
 }
 
+impl SpawnWorkflowResponse {
+    pub fn good(workflow_status: WorkflowInstance) -> Self {
+        Self {
+            response_error: None,
+            workflow_status: Some(workflow_status),
+        }
+    }
+}
+
 #[async_trait::async_trait]
 pub trait WorkflowInstanceAPI: WorkflowInstanceAPIClone + Send + Sync {
     async fn start(&mut self, request: SpawnWorkflowRequest) -> anyhow::Result<SpawnWorkflowResponse>;

--- a/edgeless_bal/src/http_egress.rs
+++ b/edgeless_bal/src/http_egress.rs
@@ -130,13 +130,13 @@ impl edgeless_api::resource_configuration::ResourceConfigurationAPI for EgressRe
     async fn start(
         &mut self,
         _instance_specification: edgeless_api::resource_configuration::ResourceInstanceSpecification,
-    ) -> anyhow::Result<edgeless_api::function_instance::InstanceId> {
+    ) -> anyhow::Result<edgeless_api::resource_configuration::SpawnResourceResponse> {
         let new_id = edgeless_api::function_instance::InstanceId::new(self.resource_provider_id.node_id);
         let dataplane_handle = self.dataplane_provider.get_handle_for(new_id.clone()).await;
 
         self.egress_instances.insert(new_id.clone(), EgressResource::new(dataplane_handle).await);
 
-        Ok(new_id)
+        Ok(edgeless_api::resource_configuration::SpawnResourceResponse::good(new_id))
     }
 
     async fn stop(&mut self, resource_id: edgeless_api::function_instance::InstanceId) -> anyhow::Result<()> {

--- a/edgeless_bal/src/http_ingress.rs
+++ b/edgeless_bal/src/http_ingress.rs
@@ -157,7 +157,7 @@ impl edgeless_api::resource_configuration::ResourceConfigurationAPI for IngressR
     async fn start(
         &mut self,
         instance_specification: edgeless_api::resource_configuration::ResourceInstanceSpecification,
-    ) -> anyhow::Result<edgeless_api::function_instance::InstanceId> {
+    ) -> anyhow::Result<edgeless_api::resource_configuration::SpawnResourceResponse> {
         let mut lck = self.configuration_state.lock().await;
         if let (Some(host), Some(methods)) = (
             instance_specification.configuration.get("host"),
@@ -186,9 +186,15 @@ impl edgeless_api::resource_configuration::ResourceConfigurationAPI for IngressR
                 allow: allowed_methods,
                 target: target,
             });
-            Ok(resource_id.clone())
+            Ok(edgeless_api::resource_configuration::SpawnResourceResponse::good(resource_id))
         } else {
-            Err(anyhow::anyhow!("Missing Resource Configuration"))
+            Ok(edgeless_api::resource_configuration::SpawnResourceResponse {
+                response_error: Some(edgeless_api::common::ResponseError {
+                    summary: "Error when creating a resource".to_string(),
+                    detail: Some("Missing Resource Configuration".to_string()),
+                }),
+                instance_id: None,
+            })
         }
     }
     async fn stop(&mut self, resource_id: edgeless_api::function_instance::InstanceId) -> anyhow::Result<()> {

--- a/edgeless_con/src/controller.rs
+++ b/edgeless_con/src/controller.rs
@@ -266,9 +266,8 @@ impl Controller {
                     }
 
                     active_workflows.insert(spawn_workflow_request.workflow_id.clone(), wf.clone());
-                    match reply_sender.send(Ok(edgeless_api::workflow_instance::SpawnWorkflowResponse {
-                        response_error: None,
-                        workflow_status: Some(edgeless_api::workflow_instance::WorkflowInstance {
+                    match reply_sender.send(Ok(edgeless_api::workflow_instance::SpawnWorkflowResponse::good(
+                        edgeless_api::workflow_instance::WorkflowInstance {
                             workflow_id: spawn_workflow_request.workflow_id,
                             functions: wf
                                 .function_instances
@@ -278,8 +277,8 @@ impl Controller {
                                     instances: instances.clone(),
                                 })
                                 .collect(),
-                        }),
-                    })) {
+                        },
+                    ))) {
                         Ok(_) => {}
                         Err(err) => {
                             log::error!("Unhandled: {:?}", err);

--- a/edgeless_con/src/controller/test.rs
+++ b/edgeless_con/src/controller/test.rs
@@ -37,13 +37,16 @@ impl edgeless_api::function_instance::FunctionInstanceAPI for MockFunctionInstan
     async fn start(
         &mut self,
         spawn_request: edgeless_api::function_instance::SpawnFunctionRequest,
-    ) -> anyhow::Result<edgeless_api::function_instance::InstanceId> {
+    ) -> anyhow::Result<edgeless_api::function_instance::SpawnFunctionResponse> {
         let new_id = edgeless_api::function_instance::InstanceId::new(self.node_id);
         self.sender
             .send(MockFunctionInstanceEvent::Start((new_id.clone(), spawn_request)))
             .await
             .unwrap();
-        Ok(new_id)
+        Ok(edgeless_api::function_instance::SpawnFunctionResponse {
+            response_error: None,
+            instance_id: Some(new_id),
+        })
     }
     async fn stop(&mut self, id: edgeless_api::function_instance::InstanceId) -> anyhow::Result<()> {
         self.sender.send(MockFunctionInstanceEvent::Stop(id)).await.unwrap();

--- a/edgeless_con/src/controller/test.rs
+++ b/edgeless_con/src/controller/test.rs
@@ -79,13 +79,13 @@ impl edgeless_api::resource_configuration::ResourceConfigurationAPI for MockReso
     async fn start(
         &mut self,
         instance_specification: edgeless_api::resource_configuration::ResourceInstanceSpecification,
-    ) -> anyhow::Result<edgeless_api::function_instance::InstanceId> {
+    ) -> anyhow::Result<edgeless_api::resource_configuration::SpawnResourceResponse> {
         let new_id = edgeless_api::function_instance::InstanceId::new(self.node_id);
         self.sender
             .send(MockResourceEvent::Start((new_id.clone(), instance_specification)))
             .await
             .unwrap();
-        Ok(new_id)
+        Ok(edgeless_api::resource_configuration::SpawnResourceResponse::good(new_id))
     }
     async fn stop(&mut self, resource_id: edgeless_api::function_instance::InstanceId) -> anyhow::Result<()> {
         self.sender.send(MockResourceEvent::Stop(resource_id)).await.unwrap();

--- a/edgeless_node/src/agent/mod.rs
+++ b/edgeless_node/src/agent/mod.rs
@@ -101,10 +101,7 @@ impl edgeless_api::function_instance::FunctionInstanceAPI for FunctionInstanceCl
             }
         };
         match self.sender.send(AgentRequest::SPAWN(request)).await {
-            Ok(_) => Ok(edgeless_api::function_instance::SpawnFunctionResponse {
-                response_error: None,
-                instance_id: Some(f_id),
-            }),
+            Ok(_) => Ok(edgeless_api::function_instance::SpawnFunctionResponse::good(f_id)),
             Err(err) => Err(anyhow::anyhow!(
                 "Agent channel error when creating a function instance: {}",
                 err.to_string()

--- a/edgeless_node/src/agent/mod.rs
+++ b/edgeless_node/src/agent/mod.rs
@@ -90,7 +90,7 @@ impl edgeless_api::function_instance::FunctionInstanceAPI for FunctionInstanceCl
     async fn start(
         &mut self,
         request: edgeless_api::function_instance::SpawnFunctionRequest,
-    ) -> anyhow::Result<edgeless_api::function_instance::InstanceId> {
+    ) -> anyhow::Result<edgeless_api::function_instance::SpawnFunctionResponse> {
         let mut request = request;
         let f_id = match request.instance_id.clone() {
             Some(id) => id,
@@ -101,21 +101,33 @@ impl edgeless_api::function_instance::FunctionInstanceAPI for FunctionInstanceCl
             }
         };
         match self.sender.send(AgentRequest::SPAWN(request)).await {
-            Ok(_) => Ok(f_id),
-            Err(_) => Err(anyhow::anyhow!("Agent Channel Error")),
+            Ok(_) => Ok(edgeless_api::function_instance::SpawnFunctionResponse {
+                response_error: None,
+                instance_id: Some(f_id),
+            }),
+            Err(err) => Err(anyhow::anyhow!(
+                "Agent channel error when creating a function instance: {}",
+                err.to_string()
+            )),
         }
     }
     async fn stop(&mut self, id: edgeless_api::function_instance::InstanceId) -> anyhow::Result<()> {
         match self.sender.send(AgentRequest::STOP(id)).await {
             Ok(_) => Ok(()),
-            Err(_) => Err(anyhow::anyhow!("Agent Channel Error")),
+            Err(err) => Err(anyhow::anyhow!(
+                "Agent channel error when stopping a function instance: {}",
+                err.to_string()
+            )),
         }
     }
 
     async fn update_links(&mut self, update: edgeless_api::function_instance::UpdateFunctionLinksRequest) -> anyhow::Result<()> {
         match self.sender.send(AgentRequest::UPDATE(update)).await {
             Ok(_) => Ok(()),
-            Err(_) => Err(anyhow::anyhow!("Agent Channel Error")),
+            Err(err) => Err(anyhow::anyhow!(
+                "Agent channel error when updating the links of a function instance: {}",
+                err.to_string()
+            )),
         }
     }
 }


### PR DESCRIPTION
Added semantic failure to the Start method in the workflow/function/resource APIs.

For the other methods (Stop/Update/List) it is less critical to do the same since the callee should never _reject_ the request, except for exceptional cases, such as internal server error or an invalid request.

The next step is to handle the failure on the caller side, but that's another issue ;-)