### PR TITLE
add a simple Grafana dashboard for edgeless_inabox with one node

### DIFF
--- a/edgeless_node/src/lib.rs
+++ b/edgeless_node/src/lib.rs
@@ -20,7 +20,9 @@ pub async fn edgeless_node_main(settings: EdgelessNodeSettings) {
     let state_manager = Box::new(state_management::StateManager::new().await);
     let data_plane =
         edgeless_dataplane::handle::DataplaneProvider::new(settings.node_id.clone(), settings.invocation_url.clone(), settings.peers.clone()).await;
-    let telemetry_provider = edgeless_telemetry::telemetry_events::TelemetryProcessor::new(settings.metrics_url.clone()).await;
+    let telemetry_provider = edgeless_telemetry::telemetry_events::TelemetryProcessor::new(settings.metrics_url.clone())
+        .await
+        .expect(&format!("could not build the telemetry provider at URL {}", &settings.metrics_url));
     let (rust_runner_client, rust_runner_task) = wasm_runner::runner::Runner::new(
         data_plane.clone(),
         state_manager.clone(),

--- a/edgeless_telemetry/README.md
+++ b/edgeless_telemetry/README.md
@@ -1,0 +1,37 @@
+# Edgeless Telemetry
+
+This is an initial take on telemetry (to be extended / replaced as needed). Uses
+OpenMetrics through this library: https://github.com/prometheus/client_rust.
+
+Dockerfiles for running a prometheus instance and Grafana istance are provided
+with a basic dashboard for a one-node Edgeless s=ystem. Currently used by the
+edgeless_node to provide metrics such as:
+- function_count - number of function instances that are present
+- execution_times_count - number of times a function was executed
+etc.
+- execution_times_bucket - 
+
+This has been tested on a local setup with Docker for Mac and edgeless_inabox
+running locally.
+
+## How to run Prometheus / Grafana as docker containers?
+Make sure you have Docker Compose installed. Navigate to `components` and run:
+
+```bash
+docker-compose up --build -d
+```
+
+Then just open `localhost:3000` in your browser and open the `Edgeless default
+dashboard` on the left.
+
+## How to add new metric types?
+TODO
+
+## How to instrument your code?
+Instrumentation is currently added to edgeless_node, check it out to learn more.
+
+## Next steps:
+- [x] Grafana dashboard for a cluster of one node
+- [ ] Add function_class as a label for metrics
+- [ ] expand Instructions on how to add metrics
+- [x] default anonymous user

--- a/edgeless_telemetry/components/docker-compose.yml
+++ b/edgeless_telemetry/components/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+  prometheus:
+    build:
+      context: ./prometheus
+      dockerfile: Dockerfile
+    ports:
+      - 9090:9090
+      - 7003:7003 # TODO: pass this as env variable? this is the metrics port on an edgeless node
+  grafana:
+    build:
+      context: ./grafana
+      dockerfile: Dockerfile
+    ports:
+      - 3000:3000
+    depends_on:
+      - prometheus

--- a/edgeless_telemetry/components/grafana/Dockerfile
+++ b/edgeless_telemetry/components/grafana/Dockerfile
@@ -1,0 +1,14 @@
+FROM grafana/grafana
+
+# copy the custom config file
+COPY custom.ini /etc/grafana/grafana.ini
+
+# copy the files needed to provision a default dashboard and datasource
+COPY default-datasource-provider.yaml /etc/grafana/provisioning/datasources/main.yaml
+COPY default-dashboard-provider.yaml /etc/grafana/provisioning/dashboards/main.yaml
+COPY default-dashboard.json /var/lib/grafana/dashboards/main-dashboard.json
+
+EXPOSE 3000 
+
+# we need to pass the config to the server command
+CMD ["grafana-server", "--config=/etc/grafana/grafana.ini"]

--- a/edgeless_telemetry/components/grafana/custom.ini
+++ b/edgeless_telemetry/components/grafana/custom.ini
@@ -1,0 +1,14 @@
+[users]
+allow_org_create = true
+auto_assign_org = true
+
+# accessing localhost:3000 will get you directly to the dashboards view
+[auth]
+disable_login_form = true
+
+[auth.anonymous]
+enabled = true
+
+# Role for unauthenticated users, other valid values are `Editor` and `Admin`
+org_role = Admin
+hide_version = true

--- a/edgeless_telemetry/components/grafana/default-dashboard-provider.yaml
+++ b/edgeless_telemetry/components/grafana/default-dashboard-provider.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+providers:
+  - name: "Dashboard provider"
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true
+    dashboard:
+      id: null
+      uid: 17fad301-dbec-47ef-adfe-77e303381ed4
+      title: Edgeless default dashboard

--- a/edgeless_telemetry/components/grafana/default-dashboard.json
+++ b/edgeless_telemetry/components/grafana/default-dashboard.json
@@ -1,0 +1,367 @@
+{
+    "__elements": {},
+    "__requires": [
+        {
+            "type": "grafana",
+            "id": "grafana",
+            "name": "Grafana",
+            "version": "10.2.0"
+        },
+        {
+            "type": "panel",
+            "id": "histogram",
+            "name": "Histogram",
+            "version": ""
+        },
+        {
+            "type": "datasource",
+            "id": "prometheus",
+            "name": "Prometheus",
+            "version": "1.0.0"
+        },
+        {
+            "type": "panel",
+            "id": "stat",
+            "name": "Stat",
+            "version": ""
+        },
+        {
+            "type": "panel",
+            "id": "timeseries",
+            "name": "Time series",
+            "version": ""
+        }
+    ],
+    "annotations": {
+        "list": [
+            {
+                "builtIn": 1,
+                "datasource": {
+                    "type": "grafana",
+                    "uid": "-- Grafana --"
+                },
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+            "datasource": "PrometheusDatasource",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "blue",
+                                "value": null
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 0
+            },
+            "id": 3,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "10.2.0",
+            "targets": [
+                {
+                    "datasource": "PrometheusDatasource",
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "expr": "execution_times_count",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": true,
+                    "instant": false,
+                    "legendFormat": "{{function_id}}",
+                    "range": true,
+                    "refId": "A",
+                    "useBackend": false
+                }
+            ],
+            "title": "Total number of invocations per function instance",
+            "type": "stat"
+        },
+        {
+            "datasource": "PrometheusDatasource",
+            "description": "",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    },
+                    "unit": "none"
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 0
+            },
+            "id": 1,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "",
+                    "values": false
+                },
+                "textMode": "auto"
+            },
+            "pluginVersion": "10.2.0",
+            "targets": [
+                {
+                    "datasource": "PrometheusDatasource",
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "expr": "function_count",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": true,
+                    "instant": false,
+                    "legendFormat": "__auto",
+                    "range": true,
+                    "refId": "A",
+                    "useBackend": false
+                }
+            ],
+            "title": "Running function instances",
+            "type": "stat"
+        },
+        {
+            "datasource": "PrometheusDatasource",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "custom": {
+                        "fillOpacity": 21,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "lineWidth": 1
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 8
+            },
+            "id": 5,
+            "options": {
+                "bucketOffset": 0,
+                "bucketSize": 0,
+                "combine": false,
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                }
+            },
+            "targets": [
+                {
+                    "datasource": "PrometheusDatasource",
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "expr": "rate(execution_times_sum[10m]) / rate(execution_times_count[10m])",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": true,
+                    "instant": false,
+                    "legendFormat": "__auto",
+                    "range": true,
+                    "refId": "A",
+                    "useBackend": false
+                }
+            ],
+            "title": "Execution time histogram (WIP)",
+            "type": "histogram"
+        },
+        {
+            "datasource": "PrometheusDatasource",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "palette-classic"
+                    },
+                    "custom": {
+                        "axisBorderShow": false,
+                        "axisCenteredZero": false,
+                        "axisColorMode": "text",
+                        "axisLabel": "",
+                        "axisPlacement": "auto",
+                        "barAlignment": 0,
+                        "drawStyle": "line",
+                        "fillOpacity": 0,
+                        "gradientMode": "none",
+                        "hideFrom": {
+                            "legend": false,
+                            "tooltip": false,
+                            "viz": false
+                        },
+                        "insertNulls": false,
+                        "lineInterpolation": "linear",
+                        "lineWidth": 1,
+                        "pointSize": 5,
+                        "scaleDistribution": {
+                            "type": "linear"
+                        },
+                        "showPoints": "auto",
+                        "spanNulls": false,
+                        "stacking": {
+                            "group": "A",
+                            "mode": "none"
+                        },
+                        "thresholdsStyle": {
+                            "mode": "off"
+                        }
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 8
+            },
+            "id": 2,
+            "options": {
+                "legend": {
+                    "calcs": [],
+                    "displayMode": "list",
+                    "placement": "bottom",
+                    "showLegend": true
+                },
+                "tooltip": {
+                    "mode": "single",
+                    "sort": "none"
+                }
+            },
+            "targets": [
+                {
+                    "datasource": "PrometheusDatasource",
+                    "disableTextWrap": false,
+                    "editorMode": "builder",
+                    "exemplar": false,
+                    "expr": "avg by(function_id) (sum by(function_id) (rate(execution_times_count[$__interval])))",
+                    "format": "time_series",
+                    "fullMetaSearch": false,
+                    "includeNullMetadata": true,
+                    "instant": false,
+                    "interval": "",
+                    "legendFormat": "",
+                    "range": true,
+                    "refId": "invocations_per_second",
+                    "useBackend": false
+                }
+            ],
+            "title": "Function invocations rate",
+            "type": "timeseries"
+        }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 38,
+    "tags": [],
+    "templating": {
+        "list": []
+    },
+    "time": {
+        "from": "now-5m",
+        "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Edgeless default dashboard",
+    "uid": "17fad301-dbec-47ef-adfe-77e303381ed4",
+    "version": 1,
+    "weekStart": ""
+}

--- a/edgeless_telemetry/components/grafana/default-datasource-provider.yaml
+++ b/edgeless_telemetry/components/grafana/default-datasource-provider.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: PrometheusDatasource
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/edgeless_telemetry/components/prometheus/Dockerfile
+++ b/edgeless_telemetry/components/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus
+ADD prometheus.yml /etc/prometheus

--- a/edgeless_telemetry/components/prometheus/prometheus.yml
+++ b/edgeless_telemetry/components/prometheus/prometheus.yml
@@ -1,0 +1,16 @@
+# Configures a local prometheus container that can be used ...
+global:
+  scrape_interval: 15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: "codelab-monitor"
+
+# A scrape configuration containing exactly one endpoint to scrape: Here it's
+# Prometheus itself.
+scrape_configs:
+  - job_name: "edgeless-node"
+    scrape_interval: 1s
+    static_configs:
+      - targets: ["host.docker.internal:7003"]

--- a/edgeless_telemetry/src/prometheus_target.rs
+++ b/edgeless_telemetry/src/prometheus_target.rs
@@ -1,5 +1,6 @@
 use warp::Filter;
 
+/// Prometheus collects metrics from targets by scraping metrics HTTP targets. This struct defines that.
 pub struct PrometheusEventTarget {
     registry: std::sync::Arc<tokio::sync::Mutex<prometheus_client::registry::Registry>>,
     function_count: prometheus_client::metrics::family::Family<RuntimeLabels, prometheus_client::metrics::gauge::Gauge>,
@@ -12,6 +13,7 @@ struct RuntimeLabels {
     function_type: String,
 }
 
+// TODO: add additional labels like function_class, function_name
 #[derive(Clone, Debug, Hash, PartialEq, Eq, prometheus_client::encoding::EncodeLabelSet)]
 struct FunctionLabels {
     node_id: String,

--- a/edgeless_telemetry/src/telemetry_events.rs
+++ b/edgeless_telemetry/src/telemetry_events.rs
@@ -31,7 +31,7 @@ pub fn telemetry_to_api(lvl: TelemetryLogLevel) -> String {
 pub enum TelemetryEvent {
     FunctionInstantiate(std::time::Duration),
     FunctionInit(std::time::Duration),
-    FunctionLogEntry(TelemetryLogLevel, String, String),
+    FunctionLogEntry(TelemetryLogLevel, String, String), // (_, target, msg)
     FunctionInvocationCompleted(std::time::Duration),
     FunctionStop(std::time::Duration),
     FunctionExit,
@@ -125,6 +125,7 @@ pub struct TelemetryProcessor {
 
 impl TelemetryProcessor {
     pub async fn new(metrics_url: String) -> Self {
+        // TODO: this should not be hardcoded in the future
         let mut listen_port: u16 = 7003;
         if let Ok((_, _, port)) = edgeless_api::util::parse_http_host(&metrics_url) {
             listen_port = port;


### PR DESCRIPTION
Hacked together a very basic dashboard in grafana together with a docker-compose file to start a prometheus and grafana instances. Metrics endopoint is hardcoded for now. Let me know what you think!