### PR TITLE
Add multiple runners to agent

### DIFF
--- a/edgeless_api_core/src/instance_id.rs
+++ b/edgeless_api_core/src/instance_id.rs
@@ -43,6 +43,12 @@ impl<C> minicbor::Decode<'_, C> for InstanceId {
     }
 }
 
+impl core::fmt::Display for InstanceId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "InstanceId(node_id: {}, function_id: {})", self.node_id, self.function_id)
+    }
+}
+
 impl InstanceId {
     pub fn new(node_id: uuid::Uuid) -> Self {
         Self {

--- a/edgeless_benchmark/src/lib.rs
+++ b/edgeless_benchmark/src/lib.rs
@@ -93,8 +93,9 @@ pub async fn edgeless_metrics_collector_node_main(settings: edgeless_node::Edgel
     );
 
     // Create the agent.
-    let (mut agent, agent_task) =
-        edgeless_node::agent::Agent::new(Box::new(rust_runtime_client.clone()), resources, settings.clone(), data_plane.clone());
+    let mut runners = std::collections::HashMap::<String, Box<dyn edgeless_node::base_runtime::RuntimeAPI + Send>>::new();
+    runners.insert("RUST_WASM".to_string(), Box::new(rust_runtime_client.clone()));
+    let (mut agent, agent_task) = edgeless_node::agent::Agent::new(runners, resources, settings.clone(), data_plane.clone());
     let agent_api_server = edgeless_api::grpc_impl::agent::AgentAPIServer::run(agent.get_api_client(), settings.agent_url.clone());
 
     // Wait for all the tasks to complete.

--- a/edgeless_node/src/lib.rs
+++ b/edgeless_node/src/lib.rs
@@ -268,7 +268,9 @@ pub async fn edgeless_node_main(settings: EdgelessNodeSettings) {
     let resources = fill_resources(data_plane.clone(), &settings, &mut resource_provider_specifications).await;
 
     // Create the agent.
-    let (mut agent, agent_task) = agent::Agent::new(Box::new(rust_runtime_client.clone()), resources, settings.clone(), data_plane.clone());
+    let mut runners = std::collections::HashMap::<String, Box<dyn crate::base_runtime::RuntimeAPI + Send>>::new();
+    runners.insert("RUST_WASM".to_string(), Box::new(rust_runtime_client.clone()));
+    let (mut agent, agent_task) = agent::Agent::new(runners, resources, settings.clone(), data_plane.clone());
     let agent_api_server = edgeless_api::grpc_impl::agent::AgentAPIServer::run(agent.get_api_client(), settings.agent_url.clone());
 
     // Wait for all the tasks to complete.


### PR DESCRIPTION
In preparation of having multiple function classes (e.g., `RUST_WASM`, `WASM_SGX`) it makes sense to switch the function execution class at agent level. Doing so allows one node to run multiple runners with potentially different capabilities. 

Added a hash map of runners instead of just the default `RUST_WASM` runner. This can be extended for debug purposes or meaningfully enriched in future deployments. As the `AgentRequests` are not really consistent with each other (i.e., some provide `instanceId`s, some `functionId`s, some also the class), it is also necessary to save the existing functions with their `componentId` to later find the `function class` and the respective runner.