### PR TITLE
Container runner updates to fix issue #226, related to functions execution in SGX

### DIFF
--- a/edgeless_node/Cargo.toml
+++ b/edgeless_node/Cargo.toml
@@ -60,7 +60,10 @@ wasmi = { version = "0.31", default-features = false, optional = true }
 tonic = "0.11.0"
 prost = "0.12.6"
 base64 = "0.22.1"
-rs-docker = "0.0.58"
+# A fork is used instead of the actual crate code because Devices support is needed for Intel SGX
+# But is not implemented in the latest version of rs-docker "0.0.60"
+# See this GitHub issue: https://github.com/edgeless-project/edgeless/issues/226 for more information
+rs-docker = { version = "0.0.61", git = "https://github.com/edgeless-project/rust-docker.git" }
 chrono = "0.4.38"
 ollama-rs = { version = "0.2.0", features = ["chat-history"] }
 rdkafka = { version = "0.36.2", optional = true }

--- a/edgeless_node/src/container_runner/container_devices.rs
+++ b/edgeless_node/src/container_runner/container_devices.rs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2024 Technical University of Crete
+// SPDX-License-Identifier: MIT
+
+use rs_docker::container::DeviceStruct;
+
+pub fn get_sgx_out_of_tree_driver() -> DeviceStruct {
+    DeviceStruct {
+        CgroupPermissions: "rwm".to_string(),
+        PathOnHost: "/dev/isgx".to_string(),
+        PathInContainer: "/dev/isgx".to_string(),
+    }
+}
+
+pub fn get_sgx_in_tree_driver() -> DeviceStruct {
+    DeviceStruct {
+        CgroupPermissions: "rwm".to_string(),
+        PathOnHost: "/dev/sgx_enclave".to_string(),
+        PathInContainer: "/dev/sgx_enclave".to_string(),
+    }
+}
+
+pub fn get_sgx_nuc_driver() -> DeviceStruct {
+    get_sgx_out_of_tree_driver()
+}

--- a/edgeless_node/src/container_runner/mod.rs
+++ b/edgeless_node/src/container_runner/mod.rs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: © 2023 Claudio Cicconetti <c.cicconetti@iit.cnr.it>
 // SPDX-License-Identifier: MIT
 
+pub mod container_devices;
+
 pub mod container_runtime;
 
 pub mod docker_utils;

--- a/edgeless_node/src/container_runner/test/mod.rs
+++ b/edgeless_node/src/container_runner/test/mod.rs
@@ -49,6 +49,7 @@ fn test_docker_basic() {
 
     let name = uuid::Uuid::new_v4();
     let image_name = "edgeless_function".to_string();
+    let devices = vec![];
 
     match docker.create_container(
         name.to_string(),
@@ -60,6 +61,7 @@ fn test_docker_basic() {
                 NetworkMode: None,
                 PublishAllPorts: Some(true),
                 PortBindings: None,
+                Devices: Some(devices),
             }),
         },
     ) {


### PR DESCRIPTION
To support these changes and facilitate easier tracking, a fork of the [rs-docker](https://github.com/edgeless-project/rust-docker) was also created, as discussed.

This PR will enable the node to start containers created using the [SecureExecutor](https://github.com/edgeless-project/SecureExecutor.git) tool, which requires passing the SGX driver during container initiation.

Instructions for generating trusted function images can be found [here](https://github.com/edgeless-project/SecureExecutor/blob/main/doc/edgeless-function.md).