### PR TITLE
Upgrade Github Actions actions/upload-artifact

### DIFF
--- a/.github/workflows/commit_checks.yml
+++ b/.github/workflows/commit_checks.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build x64 Release
         run: cargo build --release
       - name: Upload Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries
           path: |


### PR DESCRIPTION
actions/upload-artifact v3 is deprecated since January 30th, 2025. See: [Deprecation notice: v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)