### PR TITLE
Add base support for metadata propagation around event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
  "heapless",
  "log",
  "minicbor",
+ "opentelemetry",
  "uuid",
 ]
 
@@ -1877,6 +1878,7 @@ dependencies = [
  "log",
  "ollama-rs",
  "openssl",
+ "opentelemetry",
  "prost 0.13.5",
  "rand",
  "rdkafka",
@@ -4985,6 +4987,19 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ members = [
     "edgeless_systemtests",
     "edgeless_telemetry",
 ]
+
+[workspace.dependencies]
+opentelemetry = { version = "0.30.0", default-features = false, features = ["trace"] }

--- a/edgeless_api/proto/messages.proto
+++ b/edgeless_api/proto/messages.proto
@@ -488,18 +488,28 @@ message EventTimestamp {
     uint32 nsecs  = 2;
 }
 
+// Metadata associated with an event.
+message EventSerializedMetadata {
+    // The Trace ID representing the trace that the span is a part of (16-byte array)
+    bytes trace_id = 1;
+    // The span’s Span ID (8-byte array)
+    bytes span_id  = 2;
+}
+
 // Event.
 message Event {
     // The function instance that is expected to handle the event (callee).
-    InstanceId     target     = 1;
+    InstanceId target                = 1;
     // The function instance that generated the event (caller).
-    InstanceId     source     = 2;
+    InstanceId source                = 2;
     // Ongoing transaction identifier.
-    uint64         stream_id  = 3;
+    uint64 stream_id                 = 3;
     // Event data.
-    EventData      msg        = 4;
+    EventData msg                    = 4;
     // Timestamp of when the message was created.
-    EventTimestamp created    = 5;
+    EventTimestamp created           = 5;
+    // Metadata that contain the tracing id
+    EventSerializedMetadata metadata = 6;
 }
 
 // Resource provider specification.
@@ -636,16 +646,19 @@ message TelemetryLogEvent {
 // Argument of GuestAPIHost::DelayedCast().
 message DelayedEventData {
     // The event originator (to identify the function instance on the host).
-    InstanceId originator = 1;
+    InstanceId originator            = 1;
 
     // The alias of the function instance recipient of this event.
-    string alias          = 2;
+    string alias                     = 2;
     
     // The event payload. Can be empty.
-    bytes msg             = 3;
+    bytes msg                        = 3;
 
     // The delay after which this event has to be generated, in ms.
-    uint64 delay          = 4;
+    uint64 delay                     = 4;
+
+    // Metadata that contain the tracing id
+    EventSerializedMetadata metadata = 5;
 }
 
 // Argument of GuestAPIHost::Sync().

--- a/edgeless_api/src/coap_impl/invocation.rs
+++ b/edgeless_api/src/coap_impl/invocation.rs
@@ -48,6 +48,7 @@ impl CoapInvocationServer {
                                 edgeless_api_core::invocation::EventData::Err => crate::invocation::EventData::Err,
                             },
                             created: invocation_event.created,
+                            metadata: invocation_event.metadata,
                         };
 
                         let key_entry = received_tokens.entry(sender.ip());
@@ -91,6 +92,7 @@ impl crate::invocation::InvocationAPI for super::CoapClient {
                 crate::invocation::EventData::Err => edgeless_api_core::invocation::EventData::Err,
             },
             created: event.created,
+            metadata: event.metadata,
         };
 
         let mut lck = self.inner.lock().await;

--- a/edgeless_api/src/function_instance.rs
+++ b/edgeless_api/src/function_instance.rs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: © 2023 Siemens AG
 // SPDX-License-Identifier: MIT
 
+pub use edgeless_api_core::event_metadata::*;
 pub use edgeless_api_core::event_timestamp::*;
 pub use edgeless_api_core::instance_id::*;
 

--- a/edgeless_api/src/grpc_impl/inner/guest_api_host.rs
+++ b/edgeless_api/src/grpc_impl/inner/guest_api_host.rs
@@ -285,6 +285,10 @@ fn parse_delayed_event_data(api_instance: &crate::grpc_impl::api::DelayedEventDa
         delay: api_instance.delay,
         alias: api_instance.alias.clone(),
         msg: api_instance.msg.clone(),
+        metadata: match &api_instance.metadata {
+            Some(metadata) => metadata.try_into()?,
+            None => return Err(anyhow::anyhow!("the serialized metadata field is missing")),
+        },
     })
 }
 
@@ -338,6 +342,7 @@ fn serialize_delayed_event_data(event: &crate::guest_api_host::DelayedEventData)
         delay: event.delay,
         alias: event.alias.clone(),
         msg: event.msg.clone(),
+        metadata: Some(crate::grpc_impl::api::EventSerializedMetadata::from(&event.metadata)),
     }
 }
 
@@ -442,12 +447,14 @@ mod test {
                 delay: 0_u64,
                 alias: "".to_string(),
                 msg: vec![],
+                metadata: edgeless_api_core::event_metadata::EventMetadata::from_uints(0x42a42bdecaf00007u128, 0x42a42bdecaf00008u64),
             },
             DelayedEventData {
                 originator: edgeless_api_core::instance_id::InstanceId::new(uuid::Uuid::new_v4()),
                 delay: 42_u64,
                 alias: "my-fun".to_string(),
                 msg: vec![0, 42, 0, 42, 99],
+                metadata: edgeless_api_core::event_metadata::EventMetadata::from_uints(0x42a42bdecaf00009u128, 0x42a42bdecaf0000au64),
             },
         ];
         for msg in messages {

--- a/edgeless_api/src/grpc_impl/outer/invocation.rs
+++ b/edgeless_api/src/grpc_impl/outer/invocation.rs
@@ -19,6 +19,11 @@ impl InvocationConverters {
             stream_id: api_event.stream_id,
             data: Self::parse_api_event_data(api_event.msg.as_ref().unwrap())?,
             created: CommonConverters::parse_event_timestamp(api_event.created.as_ref().unwrap())?,
+            metadata: api_event
+                .metadata
+                .as_ref()
+                .ok_or(anyhow::anyhow!("the serialized metadata field is missing"))
+                .and_then(|x| x.try_into())?,
         })
     }
 
@@ -39,6 +44,7 @@ impl InvocationConverters {
             stream_id: crate_event.stream_id,
             msg: Some(Self::encode_crate_event_data(&crate_event.data)),
             created: Some(CommonConverters::serialize_event_timestamp(&crate_event.created)),
+            metadata: Some(crate::grpc_impl::api::EventSerializedMetadata::from(&crate_event.metadata)),
         }
     }
 

--- a/edgeless_api/src/guest_api_host.rs
+++ b/edgeless_api/src/guest_api_host.rs
@@ -38,6 +38,7 @@ pub struct DelayedEventData {
     pub alias: String,
     pub msg: Vec<u8>,
     pub delay: u64,
+    pub metadata: edgeless_api_core::event_metadata::EventMetadata,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/edgeless_api/src/invocation.rs
+++ b/edgeless_api/src/invocation.rs
@@ -31,6 +31,7 @@ pub struct Event {
     pub stream_id: u64,
     pub data: EventData,
     pub created: crate::function_instance::EventTimestamp,
+    pub metadata: crate::function_instance::EventMetadata,
 }
 
 impl std::fmt::Display for Event {

--- a/edgeless_api_core/Cargo.toml
+++ b/edgeless_api_core/Cargo.toml
@@ -40,6 +40,7 @@ heapless = "0.8"
 # prost = {version = "0.11", optional = true}
 # regex = "1.8"
 # serde = {version = "1", features=["derive"]}
+opentelemetry = { workspace = true }
 
 # [build-dependencies]
 # tonic-build = {version = "0.9", optional = true}

--- a/edgeless_api_core/src/coap_mapping.rs
+++ b/edgeless_api_core/src/coap_mapping.rs
@@ -27,6 +27,7 @@ impl COAPEncoder {
                 crate::invocation::EventData::Err => crate::invocation::EventData::Err,
             },
             created: event.created,
+            metadata: event.metadata.clone(),
         };
         minicbor::encode(&new_event, &mut buffer[..]).unwrap();
         let len = minicbor::len(&event);
@@ -257,6 +258,7 @@ impl CoapDecoder {
                         crate::invocation::EventData::Err => crate::invocation::EventData::Err,
                     },
                     created: event.created,
+                    metadata: event.metadata,
                 };
                 Ok((CoapMessage::Invocation(new_event), packet.get_token()[0]))
             }

--- a/edgeless_api_core/src/event_metadata.rs
+++ b/edgeless_api_core/src/event_metadata.rs
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: © 2023
+// SPDX-License-Identifier: MIT
+
+use opentelemetry::trace::{SpanContext, TraceFlags, TraceState};
+use opentelemetry::{SpanId, TraceId};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EventMetadata(SpanContext);
+
+impl EventMetadata {
+    pub fn from_uints(trace_id: u128, span_id: u64) -> EventMetadata {
+        EventMetadata::from(TraceId::from(trace_id), SpanId::from(span_id))
+    }
+
+    pub fn from(trace_id: TraceId, span_id: SpanId) -> EventMetadata {
+        EventMetadata(SpanContext::new(trace_id, span_id, TraceFlags::SAMPLED, true, TraceState::NONE))
+    }
+
+    pub fn from_bytes(trace_id: [u8; 16], span_id: [u8; 8]) -> EventMetadata {
+        EventMetadata::from(TraceId::from_bytes(trace_id), SpanId::from_bytes(span_id))
+    }
+
+    pub fn from_event(e: &EventMetadata) -> EventMetadata {
+        EventMetadata::from(e.trace_id(), e.span_id())
+    }
+
+    pub fn to_bytes(&self) -> [u8; 16 + 8] {
+        let mut tmp = [0u8; 24];
+        tmp[..16].copy_from_slice(&self.0.trace_id().to_bytes());
+        tmp[16..].copy_from_slice(&self.0.span_id().to_bytes());
+        tmp
+    }
+
+    pub fn trace_id(&self) -> TraceId {
+        self.0.trace_id()
+    }
+
+    pub fn span_id(&self) -> SpanId {
+        self.0.span_id()
+    }
+
+    pub fn span_context(&self) -> &SpanContext {
+        &self.0
+    }
+
+    pub fn empty_new_root() -> Self {
+        Self::from(TraceId::INVALID, SpanId::INVALID)
+    }
+
+    pub fn empty_dangling_root(offset: u64) -> Self {
+        Self::from(TraceId::INVALID, SpanId::from(offset))
+    }
+}
+
+impl<'b, C> minicbor::Decode<'b, C> for EventMetadata {
+    fn decode(d: &mut minicbor::Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        // See https://github.com/twittner/minicbor/blob/develop/minicbor/src/decode.rs#L657
+        let octets_16: minicbor::bytes::ByteArray<16> = minicbor::Decode::decode(d, ctx)?;
+        let octets_8: minicbor::bytes::ByteArray<8> = minicbor::Decode::decode(d, ctx)?;
+        Ok(EventMetadata::from_bytes(octets_16.into(), octets_8.into()))
+    }
+}
+
+impl<C> minicbor::Encode<C> for EventMetadata {
+    fn encode<W: minicbor::encode::Write>(&self, e: &mut minicbor::Encoder<W>, _: &mut C) -> Result<(), minicbor::encode::Error<W::Error>> {
+        // See https://github.com/twittner/minicbor/blob/develop/minicbor/src/encode.rs#L876
+        e.bytes(&self.0.trace_id().to_bytes())
+            .and_then(|e| e.bytes(&self.0.span_id().to_bytes()))?
+            .ok()
+    }
+}
+
+impl<C> minicbor::CborLen<C> for EventMetadata {
+    fn cbor_len(&self, ctx: &mut C) -> usize {
+        16.cbor_len(ctx) + 8.cbor_len(ctx) + 16 + 8
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::event_metadata::EventMetadata;
+
+    #[test]
+    fn test_event_metadata_encoding() {
+        let mut buffer = [0u8; 8 + 16 + 2];
+
+        let md = EventMetadata::from_uints(0x42a42bdecaf00001u128, 0x42a42bdecaf00002u64);
+
+        minicbor::encode(&md, &mut buffer[..]).unwrap();
+
+        let len = minicbor::len(&md);
+
+        let decoded: EventMetadata = minicbor::decode(&buffer[..len]).unwrap();
+
+        assert_eq!(md, decoded);
+        assert_eq!(buffer.len(), len)
+    }
+
+    #[test]
+    fn test_event_metadata_bytes() {
+        let em_1 = EventMetadata::from_uints(0x42a42bdecaf00003u128, 0x42a42bdecaf00004u64);
+        let bytes: [u8; 24] = em_1.to_bytes();
+        let x = bytes[..16].try_into();
+        let y = bytes[16..].try_into();
+        assert!(x.is_ok());
+        let x = x.unwrap();
+        assert!(y.is_ok());
+        let y = y.unwrap();
+        let em_2 = EventMetadata::from_bytes(x, y);
+        assert_eq!(em_1, em_2)
+    }
+}

--- a/edgeless_api_core/src/invocation.rs
+++ b/edgeless_api_core/src/invocation.rs
@@ -27,6 +27,8 @@ pub struct Event<T> {
     pub data: EventData<T>,
     #[n(4)]
     pub created: crate::event_timestamp::EventTimestamp,
+    #[n(5)]
+    pub metadata: crate::event_metadata::EventMetadata,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/edgeless_api_core/src/lib.rs
+++ b/edgeless_api_core/src/lib.rs
@@ -10,6 +10,7 @@ extern crate alloc;
 
 pub mod coap_mapping;
 pub mod common;
+pub mod event_metadata;
 pub mod event_timestamp;
 pub mod instance_id;
 pub mod invocation;

--- a/edgeless_cli/src/edgeless_cli.rs
+++ b/edgeless_cli/src/edgeless_cli.rs
@@ -384,6 +384,7 @@ async fn main() -> anyhow::Result<()> {
                             _ => return Err(anyhow::anyhow!("invalid event type: {}", event_type)),
                         },
                         created: edgeless_api::function_instance::EventTimestamp::default(),
+                        metadata: edgeless_api::function_instance::EventMetadata::empty_new_root(),
                     };
                     match edgeless_api::invocation::InvocationAPI::handle(&mut client, event).await {
                         Ok(_) => println!("event casted"),

--- a/edgeless_dataplane/src/core.rs
+++ b/edgeless_dataplane/src/core.rs
@@ -15,6 +15,7 @@ pub trait DataPlaneLink: Send + Sync {
         src: &edgeless_api::function_instance::InstanceId,
         created: &edgeless_api::function_instance::EventTimestamp,
         channel_id: u64,
+        metadata: &edgeless_api::function_instance::EventMetadata,
     ) -> LinkProcessingResult;
 }
 
@@ -40,6 +41,7 @@ pub struct DataplaneEvent {
     pub channel_id: u64,
     pub message: Message,
     pub created: edgeless_api::function_instance::EventTimestamp,
+    pub metadata: edgeless_api::function_instance::EventMetadata,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]

--- a/edgeless_embedded/src/agent.rs
+++ b/edgeless_embedded/src/agent.rs
@@ -165,6 +165,7 @@ impl crate::invocation::InvocationAPI for EmbeddedAgent {
                         edgeless_api_core::invocation::EventData::Err => edgeless_api_core::invocation::EventData::Err,
                     },
                     created: event.created,
+                    metadata: event.metadata,
                 };
             self.upstream_sender.send(AgentEvent::Invocation(new_event)).await;
             Ok(edgeless_api_core::invocation::LinkProcessingResult::FINAL)

--- a/edgeless_embedded/src/coap.rs
+++ b/edgeless_embedded/src/coap.rs
@@ -322,6 +322,7 @@ impl CoapMultiplexer {
                     edgeless_api_core::invocation::EventData::Err => edgeless_api_core::invocation::EventData::Err,
                 },
                 created: event.created,
+                metadata: event.metadata.clone(),
             };
 
             let ((data, endpoint), _tail) =

--- a/edgeless_embedded/src/dataplane.rs
+++ b/edgeless_embedded/src/dataplane.rs
@@ -15,6 +15,7 @@ impl EmbeddedDataplaneHandle {
         target: edgeless_api_core::instance_id::InstanceId,
         msg: &str,
         // created: edgeless_api_core::event_timestamp::EventTimestamp,
+        metadata: &edgeless_api_core::event_metadata::EventMetadata,
     ) {
         let event = edgeless_api_core::invocation::Event::<&[u8]> {
             target,
@@ -22,6 +23,7 @@ impl EmbeddedDataplaneHandle {
             stream_id: 0,
             data: edgeless_api_core::invocation::EventData::Cast(msg.as_bytes()),
             created: edgeless_api_core::event_timestamp::EventTimestamp::default(),
+            metadata: metadata.clone(),
         };
         self.reg.handle(event).await.unwrap();
     }

--- a/edgeless_embedded/src/resource/mock_sensor.rs
+++ b/edgeless_embedded/src/resource/mock_sensor.rs
@@ -116,7 +116,14 @@ pub async fn mock_sensor_task(
         };
         if let (Some(instance_id), Some(data_out_id)) = (instance_id, data_out_id) {
             log::info!("Sensor send!");
-            dataplane_handle.send(instance_id, data_out_id, "800.12345;50.12345;20.12345").await;
+            dataplane_handle
+                .send(
+                    instance_id,
+                    data_out_id,
+                    "800.12345;50.12345;20.12345",
+                    &edgeless_api_core::event_metadata::EventMetadata::from_uints(0x42a42bdecaf0000bu128, 0x42a42bdecaf0000cu64),
+                )
+                .await;
         }
         embassy_time::Timer::after(embassy_time::Duration::from_secs(delay as u64)).await;
     }

--- a/edgeless_embedded/src/resource/scd30_sensor.rs
+++ b/edgeless_embedded/src/resource/scd30_sensor.rs
@@ -155,7 +155,14 @@ pub async fn scd30_sensor_task(
             )
             .is_ok()
             {
-                dataplane_handle.send(instance_id, data_out_id, buffer.as_str()).await;
+                dataplane_handle
+                    .send(
+                        instance_id,
+                        data_out_id,
+                        buffer.as_str(),
+                        &edgeless_api_core::event_metadata::EventMetadata::from_uints(0x42a42bdecaf0000du128, 0x42a42bdecaf0000eu64),
+                    )
+                    .await;
             }
         }
     }

--- a/edgeless_node/Cargo.toml
+++ b/edgeless_node/Cargo.toml
@@ -84,6 +84,7 @@ sqlx = { version = "0.8.0", features = [
 ] }
 edgeless_function = { path = "../edgeless_function" }
 tokio-modbus = "0.16.1"
+opentelemetry = { workspace = true }
 
 [build-dependencies]
 tonic-build = {version = "0.13.1", features = ["prost"]}

--- a/edgeless_node/src/resources/dda/mod.rs
+++ b/edgeless_node/src/resources/dda/mod.rs
@@ -315,7 +315,13 @@ impl DDAResource {
                 match target_function_id {
                     Some(target_function_id) => match dataplane_event_type.as_str() {
                         "cast" => {
-                            let _ = handle.send(target_function_id, encoded_event).await;
+                            let _ = handle
+                                .send(
+                                    target_function_id,
+                                    encoded_event,
+                                    &edgeless_api::function_instance::EventMetadata::empty_new_root(),
+                                )
+                                .await;
                         }
                         "call" => {
                             panic!("do not use calls - they will probably be removed later on");
@@ -494,6 +500,7 @@ impl DDAResource {
                     channel_id,
                     message,
                     created,
+                    metadata,
                 } = dataplane_handle.receive_next().await;
                 let started = crate::resources::observe_transfer(created, &mut telemetry_handle);
                 let message: dda::DDA = match message {
@@ -511,7 +518,7 @@ impl DDAResource {
                 let mut handle = dataplane_handle.clone();
                 let respond = {
                     move |msg: edgeless_dataplane::core::CallRet| async move {
-                        let _ = handle.reply(source_id, channel_id, msg).await;
+                        let _ = handle.reply(source_id, channel_id, msg, &metadata).await;
                     }
                 };
 

--- a/edgeless_node/src/resources/file_log.rs
+++ b/edgeless_node/src/resources/file_log.rs
@@ -79,6 +79,7 @@ impl FileLogResource {
                     channel_id,
                     message,
                     created,
+                    metadata,
                 } = dataplane_handle.receive_next().await;
                 let started = crate::resources::observe_transfer(created, &mut telemetry_handle);
 
@@ -113,7 +114,7 @@ impl FileLogResource {
                 // Reply to the caller if the resource instance was called.
                 if need_reply {
                     dataplane_handle
-                        .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Reply("".to_string()))
+                        .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Reply("".to_string()), &metadata)
                         .await;
                 }
 

--- a/edgeless_node/src/resources/http_ingress.rs
+++ b/edgeless_node/src/resources/http_ingress.rs
@@ -101,7 +101,10 @@ impl hyper::service::Service<hyper::Request<hyper::body::Incoming>> for IngressS
                         .collect(),
                 };
                 let serialized_msg = serde_json::to_string(&msg)?;
-                let res = lck.dataplane.call(target, serialized_msg).await;
+                let res = lck
+                    .dataplane
+                    .call(target, serialized_msg, &edgeless_api::function_instance::EventMetadata::empty_new_root())
+                    .await;
                 if let edgeless_dataplane::core::CallRet::Reply(data) = res {
                     let processor_response: edgeless_http::EdgelessHTTPResponse = serde_json::from_str(&data)?;
                     let mut response_builder = hyper::Response::new(http_body_util::Full::new(hyper::body::Bytes::from(

--- a/edgeless_node/src/resources/ollama.rs
+++ b/edgeless_node/src/resources/ollama.rs
@@ -108,6 +108,7 @@ impl OllamaResource {
                     channel_id: _,
                     message,
                     created,
+                    metadata,
                 } = dataplane_handle.receive_next().await;
                 let started = crate::resources::observe_transfer(created, &mut telemetry_handle);
 
@@ -134,7 +135,7 @@ impl OllamaResource {
                 match reply_receiver.await {
                     Ok(response) => match response {
                         Ok((target, response)) => {
-                            let _ = dataplane_handle.send(target, response).await;
+                            let _ = dataplane_handle.send(target, response, &metadata).await;
                         }
                         Err(err) => {
                             log::warn!("Error from ollama: {}", err)

--- a/edgeless_node/src/resources/redis.rs
+++ b/edgeless_node/src/resources/redis.rs
@@ -110,6 +110,7 @@ impl RedisResource {
                     channel_id,
                     message,
                     created,
+                    metadata,
                 } = dataplane_handle.receive_next().await;
                 let started = crate::resources::observe_transfer(created, &mut telemetry_handle);
 
@@ -127,13 +128,13 @@ impl RedisResource {
                     match connection.get::<&str, std::string::String>(&redis_key) {
                         Ok(res) => {
                             dataplane_handle
-                                .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Reply(res))
+                                .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Reply(res), &metadata)
                                 .await
                         }
                         Err(err) => {
                             log::error!("Could not get key '{}' from redis resource: {}", redis_key, err);
                             dataplane_handle
-                                .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Err)
+                                .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Err, &metadata)
                                 .await
                         }
                     };

--- a/edgeless_node/src/resources/serverless.rs
+++ b/edgeless_node/src/resources/serverless.rs
@@ -101,6 +101,7 @@ impl ServerlessResource {
                     channel_id: _,
                     message,
                     created,
+                    metadata,
                 } = dataplane_handle.receive_next().await;
                 let started = crate::resources::observe_transfer(created, &mut telemetry_handle);
 
@@ -126,7 +127,7 @@ impl ServerlessResource {
                     Ok(response) => match response {
                         Ok((target, response)) => {
                             if let Some(target) = target {
-                                let _ = dataplane_handle.send(target, response).await;
+                                let _ = dataplane_handle.send(target, response, &metadata).await;
                             }
                         }
                         Err(err) => {

--- a/edgeless_node/src/resources/sqlx.rs
+++ b/edgeless_node/src/resources/sqlx.rs
@@ -72,6 +72,7 @@ impl SqlxResource {
                     channel_id,
                     message,
                     created,
+                    metadata,
                 } = dataplane_handle.receive_next().await;
                 let started = crate::resources::observe_transfer(created, &mut telemetry_handle);
 
@@ -123,6 +124,7 @@ impl SqlxResource {
                                         source_id,
                                         channel_id,
                                         edgeless_dataplane::core::CallRet::Reply(serde_json::to_string(&response).unwrap_or_default()),
+                                        &metadata,
                                     )
                                     .await;
                             }
@@ -130,7 +132,7 @@ impl SqlxResource {
                         Err(e) => {
                             log::info!("Response from database: {:?}", e.to_string());
                             dataplane_handle
-                                .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Reply(e.to_string()))
+                                .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Reply(e.to_string()), &metadata)
                                 .await;
                         }
                     }
@@ -149,7 +151,7 @@ impl SqlxResource {
                                     response.last_insert_rowid()
                                 );
                                 dataplane_handle
-                                    .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Reply(res))
+                                    .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Reply(res), &metadata)
                                     .await;
                             }
                         }
@@ -157,14 +159,14 @@ impl SqlxResource {
                         Err(e) => {
                             log::info!("Error from state management: {:?}", e);
                             dataplane_handle
-                                .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Reply(e.to_string()))
+                                .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Reply(e.to_string()), &metadata)
                                 .await;
                         }
                     }
                 } else {
                     log::info!("Unknow operation in state management");
                     dataplane_handle
-                        .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Err)
+                        .reply(source_id, channel_id, edgeless_dataplane::core::CallRet::Err, &metadata)
                         .await;
                 };
 

--- a/edgeless_node/src/wasm_runner/test/mod.rs
+++ b/edgeless_node/src/wasm_runner/test/mod.rs
@@ -303,7 +303,9 @@ async fn is_telemetry_event_invocation_complete(receiver: &mut TelemetryReceiver
 #[tokio::test]
 async fn messaging_cast_raw_input() {
     let (_, instance_id, mut test_peer_handle, _test_peer_fid, _next_handle, _next_fid, mut telemetry_mock_receiver) = messaging_test_setup().await;
-    test_peer_handle.send(instance_id, "some_message".to_string()).await;
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf00026u128, 0x42a42bdecaf00027u64);
+
+    test_peer_handle.send(instance_id, "some_message".to_string(), &metad_1).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     assert!(is_telemetry_event_transfer(&mut telemetry_mock_receiver).await);
@@ -317,8 +319,9 @@ async fn messaging_cast_raw_input() {
 #[tokio::test]
 async fn messaging_cast_raw_output() {
     let (_, instance_id, mut test_peer_handle, _test_peer_fid, _next_handle, _next_fid, mut telemetry_mock_receiver) = messaging_test_setup().await;
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf00028u128, 0x42a42bdecaf00029u64);
 
-    test_peer_handle.send(instance_id, "test_cast_raw_output".to_string()).await;
+    test_peer_handle.send(instance_id, "test_cast_raw_output".to_string(), &metad_1).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     assert!(is_telemetry_event_transfer(&mut telemetry_mock_receiver).await);
@@ -331,14 +334,16 @@ async fn messaging_cast_raw_output() {
         test_message.message,
         edgeless_dataplane::core::Message::Cast("cast_raw_output".to_string())
     );
+    assert_eq!(metad_1, test_message.metadata);
 }
 
 // test output: call
 #[tokio::test]
 async fn messaging_call_raw_output() {
     let (_, instance_id, mut test_peer_handle, _test_peer_fid, _next_handle, _next_fid, mut telemetry_mock_receiver) = messaging_test_setup().await;
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf0002au128, 0x42a42bdecaf0002bu64);
 
-    test_peer_handle.send(instance_id, "test_call_raw_output".to_string()).await;
+    test_peer_handle.send(instance_id, "test_call_raw_output".to_string(), &metad_1).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     assert!(is_telemetry_event_transfer(&mut telemetry_mock_receiver).await);
@@ -352,9 +357,10 @@ async fn messaging_call_raw_output() {
         test_message.message,
         edgeless_dataplane::core::Message::Call("call_raw_output".to_string())
     );
+    assert_eq!(&metad_1, &test_message.metadata);
 
     test_peer_handle
-        .reply(test_message.source_id, test_message.channel_id, CallRet::NoReply)
+        .reply(test_message.source_id, test_message.channel_id, CallRet::NoReply, &test_message.metadata)
         .await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -367,8 +373,9 @@ async fn messaging_call_raw_output() {
 async fn messaging_delayed_cast_output() {
     let (_, instance_id, mut test_peer_handle, _test_peer_fid, mut next_handle, _next_fid, mut telemetry_mock_receiver) =
         messaging_test_setup().await;
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf0002cu128, 0x42a42bdecaf0002du64);
 
-    test_peer_handle.send(instance_id, "test_delayed_cast_output".to_string()).await;
+    test_peer_handle.send(instance_id, "test_delayed_cast_output".to_string(), &metad_1).await;
     let start = tokio::time::Instant::now();
 
     let test_message = next_handle.receive_next().await;
@@ -379,6 +386,7 @@ async fn messaging_delayed_cast_output() {
         test_message.message,
         edgeless_dataplane::core::Message::Cast("delayed_cast_output".to_string())
     );
+    assert_eq!(&metad_1, &test_message.metadata);
 
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -392,8 +400,9 @@ async fn messaging_delayed_cast_output() {
 async fn messaging_cast_output() {
     let (_, instance_id, mut test_peer_handle, _test_peer_fid, mut next_handle, _next_fid, mut telemetry_mock_receiver) =
         messaging_test_setup().await;
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf0001fu128, 0x42a42bdecaf0002eu64);
 
-    test_peer_handle.send(instance_id, "test_cast_output".to_string()).await;
+    test_peer_handle.send(instance_id, "test_cast_output".to_string(), &metad_1).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     assert!(is_telemetry_event_transfer(&mut telemetry_mock_receiver).await);
@@ -403,6 +412,7 @@ async fn messaging_cast_output() {
     let test_message = next_handle.receive_next().await;
     assert_eq!(test_message.source_id, instance_id);
     assert_eq!(test_message.message, edgeless_dataplane::core::Message::Cast("cast_output".to_string()));
+    assert_eq!(metad_1, test_message.metadata);
 }
 
 // test output: call
@@ -410,8 +420,9 @@ async fn messaging_cast_output() {
 async fn messaging_call_output() {
     let (_, instance_id, mut test_peer_handle, _test_peer_fid, mut next_handle, _next_fid, mut telemetry_mock_receiver) =
         messaging_test_setup().await;
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf00030u128, 0x42a42bdecaf00031u64);
 
-    test_peer_handle.send(instance_id, "test_call_output".to_string()).await;
+    test_peer_handle.send(instance_id, "test_call_output".to_string(), &metad_1).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     assert!(is_telemetry_event_transfer(&mut telemetry_mock_receiver).await);
@@ -422,8 +433,11 @@ async fn messaging_call_output() {
     let test_message = next_handle.receive_next().await;
     assert_eq!(test_message.source_id, instance_id);
     assert_eq!(test_message.message, edgeless_dataplane::core::Message::Call("call_output".to_string()));
+    assert_eq!(&metad_1, &test_message.metadata);
 
-    next_handle.reply(test_message.source_id, test_message.channel_id, CallRet::NoReply).await;
+    next_handle
+        .reply(test_message.source_id, test_message.channel_id, CallRet::NoReply, &test_message.metadata)
+        .await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     assert!(is_telemetry_event_invocation_complete(&mut telemetry_mock_receiver).await);
@@ -435,8 +449,9 @@ async fn messaging_call_output() {
 async fn function_in_call_can_be_stopped() {
     let (mut client, instance_id, mut test_peer_handle, _test_peer_fid, mut next_handle, _next_fid, mut telemetry_mock_receiver) =
         messaging_test_setup().await;
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf00032u128, 0x42a42bdecaf00033u64);
 
-    test_peer_handle.send(instance_id, "test_call_output".to_string()).await;
+    test_peer_handle.send(instance_id, "test_call_output".to_string(), &metad_1).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     assert!(is_telemetry_event_transfer(&mut telemetry_mock_receiver).await);
@@ -447,6 +462,7 @@ async fn function_in_call_can_be_stopped() {
     let test_message = next_handle.receive_next().await;
     assert_eq!(test_message.source_id, instance_id);
     assert_eq!(test_message.message, edgeless_dataplane::core::Message::Call("call_output".to_string()));
+    assert_eq!(&metad_1, &test_message.metadata);
 
     assert!(telemetry_mock_receiver.try_recv().is_err());
 
@@ -460,8 +476,9 @@ async fn function_in_call_can_be_stopped() {
 #[tokio::test]
 async fn messaging_call_raw_input_noreply() {
     let (_, instance_id, mut test_peer_handle, _test_peer_fid, _next_handle, _next_fid, mut telemetry_mock_receiver) = messaging_test_setup().await;
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf00034u128, 0x42a42bdecaf00035u64);
 
-    let ret = test_peer_handle.call(instance_id, "some_cast".to_string()).await;
+    let ret = test_peer_handle.call(instance_id, "some_cast".to_string(), &metad_1).await;
     assert_eq!(ret, CallRet::NoReply);
 
     assert!(is_telemetry_event_transfer(&mut telemetry_mock_receiver).await);
@@ -473,8 +490,9 @@ async fn messaging_call_raw_input_noreply() {
 #[tokio::test]
 async fn messaging_call_raw_input_reply() {
     let (_, instance_id, mut test_peer_handle, _test_peer_fid, _next_handle, _next_fid, mut telemetry_mock_receiver) = messaging_test_setup().await;
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf00036u128, 0x42a42bdecaf00037u64);
 
-    let ret = test_peer_handle.call(instance_id, "test_ret".to_string()).await;
+    let ret = test_peer_handle.call(instance_id, "test_ret".to_string(), &metad_1).await;
     assert_eq!(ret, CallRet::Reply("test_reply".to_string()));
 
     assert!(is_telemetry_event_transfer(&mut telemetry_mock_receiver).await);
@@ -486,8 +504,9 @@ async fn messaging_call_raw_input_reply() {
 #[tokio::test]
 async fn messaging_call_raw_input_err() {
     let (_, instance_id, mut test_peer_handle, _test_peer_fid, _next_handle, _next_fid, mut telemetry_mock_receiver) = messaging_test_setup().await;
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf00038u128, 0x42a42bdecaf00039u64);
 
-    let ret = test_peer_handle.call(instance_id, "test_err".to_string()).await;
+    let ret = test_peer_handle.call(instance_id, "test_err".to_string(), &metad_1).await;
     assert_eq!(ret, CallRet::Err);
 
     assert!(is_telemetry_event_transfer(&mut telemetry_mock_receiver).await);
@@ -500,6 +519,7 @@ async fn state_management() {
     let node_id = uuid::Uuid::new_v4();
     let instance_id = edgeless_api::function_instance::InstanceId::new(node_id);
     let instance_id_another = edgeless_api::function_instance::InstanceId::new(node_id);
+    let metad_1 = edgeless_api::function_instance::EventMetadata::from_uints(0x42a42bdecaf0003bu128, 0x42a42bdecaf0003au64);
 
     let output_mocks = std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
     let (state_mock_sender, mut state_mock_receiver) = futures::channel::mpsc::unbounded::<(uuid::Uuid, String)>();
@@ -569,7 +589,7 @@ async fn state_management() {
     assert!(telemetry_mock_receiver.try_recv().is_err());
 
     // trigger sync
-    test_peer_handle.send(instance_id, "test_cast_raw_output".to_string()).await;
+    test_peer_handle.send(instance_id, "test_cast_raw_output".to_string(), &metad_1).await;
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let (state_set_id, state_set_value) = state_mock_receiver.try_next().unwrap().unwrap();


### PR DESCRIPTION
Add some metadata attached to event and propagate this new piece of information in the Edgeless system.
This metadata contains for now the OpenTelemetry SpanContext.
For now, the metadata is just passed around but these commits update all the necessary functions signatures. The OTLP code than manipulate the SpanContext will come afterward.


These commits have been tested successfully with:
- cargo test --package edgeless_api_core --lib -- --show-output
- cargo test --package edgeless_api --lib --features grpc_impl -- --show-output
- cargo test --package edgeless_embedded --lib -- --show-output
- cargo test --package edgeless_dataplane --lib -- --show-output
- cargo test --package edgeless_cli --lib -- --show-output
- cargo test --package edgeless_node --lib -- --show-output
